### PR TITLE
fix: add gitignore to ignore DS_Store file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Fixing issue where .DS_Store file showed up in git changes. Adding gitignore to fix this issue. Expect future changes to this file to add other ignored items.